### PR TITLE
Fix uninstallable JS samples that depend on an unpublished -staging package

### DIFF
--- a/pages/js/smart-answers-standalone/package.json
+++ b/pages/js/smart-answers-standalone/package.json
@@ -14,7 +14,7 @@
     "vite": "^6.4.3"
   },
   "dependencies": {
-    "@searchstax-inc/searchstudio-ux-js": "npm:@searchstax-inc/searchstudio-ux-js-staging@^4.2.10",
+    "@searchstax-inc/searchstudio-ux-js": "npm:@searchstax-inc/searchstudio-ux-js@^4.2.10",
     "dompurify": "^3.2.5",
     "patch-package": "^8.0.1"
   }

--- a/pages/js/tabbed-nav-sample/package.json
+++ b/pages/js/tabbed-nav-sample/package.json
@@ -14,7 +14,7 @@
     "vite": "^6.4.3"
   },
   "dependencies": {
-    "@searchstax-inc/searchstudio-ux-js": "npm:@searchstax-inc/searchstudio-ux-js-staging@^4.2.27",
+    "@searchstax-inc/searchstudio-ux-js": "npm:@searchstax-inc/searchstudio-ux-js@^4.2.27",
     "dompurify": "^3.2.5",
     "patch-package": "^8.0.1"
   }

--- a/pages/js/tabbed-nav-sample/src/main.ts
+++ b/pages/js/tabbed-nav-sample/src/main.ts
@@ -62,7 +62,7 @@ searchstax.initialize({
     },
     afterSearch: (
       results: ISearchstaxParsedResult[],
-      unparsedResponse: ISearchstaxSearchResponse,
+      _unparsedResponse: ISearchstaxSearchResponse,
     ) => {
       const copy = [...results];
       return copy;


### PR DESCRIPTION
This PR proposes pointing the `smart-answers-standalone` and `tabbed-nav-sample` JavaScript samples at the published `@searchstax-inc/searchstudio-ux-js` package so that both can be installed and built. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/213. You can sign in with your GitHub ID to claim ownership of the project.

## The problem

Two of the samples linked from the README — "Smart Answers Standalone App" and "Tabbed Navigation & Facets App" — declare their SDK dependency as an alias onto `@searchstax-inc/searchstudio-ux-js-staging`. That package is not published on the public npm registry, so `npm install` in either sample fails outright for anyone outside SearchStax. They are the only two samples under `pages/js` still pointing at a `-staging` package; the other three use the published one.

Reproduced on `master` at 670ab39:

```
$ cd pages/js/smart-answers-standalone && npm install
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@searchstax-inc%2fsearchstudio-ux-js-staging - Not found
npm error 404  The requested resource '@searchstax-inc/searchstudio-ux-js-staging@^4.2.10' could not be found or you do not have permission to access it.
```

`pages/js/tabbed-nav-sample` fails the same way on `^4.2.27`, while the sibling `pages/js/searchstax-accelerator-page` installs normally (`added 130 packages`) — so it is the `-staging` alias specifically, not the environment.

## The change

Both manifests now alias onto the published `@searchstax-inc/searchstudio-ux-js`, keeping the version range each sample already pinned (`^4.2.10` and `^4.2.27` respectively) — the same result your "Remove staging from package.json files" release step produces for the samples it covers.

One extra line in `tabbed-nav-sample/src/main.ts`: its `afterSearch` callback declares an `unparsedResponse` parameter it never reads, which trips `noUnusedParameters` and stops `npm run build` with `error TS6133`. It has been that way since the sample was added and was simply unreachable while the install failed. I renamed the parameter to `_unparsedResponse`, the convention TypeScript exempts, so the signature still documents the second argument. No runtime behavior changes.

## Why it keeps coming back

The `Create Release Branch` workflow strips the `-staging` suffix using a hardcoded `PACKAGE_FILES` list. That list names `pages/js/searchstax-standalone-sample/package.json`, which was renamed to `pages/js/smart-answers-standalone` in 4fd79a8, and it has never included `pages/js/tabbed-nav-sample` — so for those two the `sed` silently logs `Warning: File ... not found` and the suffix survives into `master`. Since release branches are cut from `staging`, where every sample carries the `-staging` alias, this PR alone will be undone by the next release.

I have deliberately left that workflow edit out of this PR, since your release process is yours to own, but the fix is two list entries in `.github/workflows/create-release.yml` — replacing the stale path and adding the missing one, in both the `PACKAGE_FILES` array and the `git add` block:

```
-          "pages/js/searchstax-standalone-sample/package.json"
+          "pages/js/smart-answers-standalone/package.json"
+          "pages/js/tabbed-nav-sample/package.json"
```

## Verification

Ran `npm install` followed by `npm run build` in both samples on this branch. Both install and compile cleanly:

```
pages/js/smart-answers-standalone   added 130 packages   tsc && vite build -> built in 445ms
pages/js/tabbed-nav-sample          added 130 packages   tsc && vite build -> built in 605ms
```

Against the pre-change baseline these are the only two that move, and nothing regresses: `searchstax-accelerator-page`, `job-search-sample` and `facet-tabs-infinite-scroll` resolved and installed before the change and still do. The repo ships no test harness for the JS samples, so the samples' own `tsc && vite build` is the check being run.

One thing I cannot satisfy from outside: the `Validate PR Naming Convention` check wants a `STUDIO-` ticket in the title, and I have no way to create one in your tracker. Happy to retitle if you assign a ticket number.

## How this was managed

This work was tracked as a single story — [Fix uninstallable JS samples that depend on the unpublished -staging SDK package](https://eastagiletracker.com/projects/213/stories/79315) — on a board at https://eastagiletracker.com/projects/213 that was imported from this repository's own pull requests (134 stories) and used to manage the change end to end.

![board](https://raw.githubusercontent.com/eastagiletracker/searchstudio-ux-samples/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
